### PR TITLE
fix for navigation anchor

### DIFF
--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -262,8 +262,8 @@ figure {
 .anchor {
     display: block;
     visibility: hidden;
-    height: 45px;
-    margin-top: -45px;
+    /*height: 45px;*/
+    /*margin-top: -45px;*/
 
 }
 


### PR DESCRIPTION
Zauważyłam, że przez brak paska menu zawsze na stronie (zmienialiśmy zeby się nie zsuwał) linki nawigacyjne źle odsyłały do sekcji- zostawał pasek. Naprawiłam tak żeby było poprawnie. 